### PR TITLE
.dockerignore修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
-terraform/
-private/
+.github/
+architecture/
+e2e/
 manuals/
+node_modules/
+playwright-report/
+private/
+terraform/
+test-results/


### PR DESCRIPTION
ファイルが増えたため、Dockerイメージに組み込むファイルを限定化。